### PR TITLE
Added missing #include <stdexcept>

### DIFF
--- a/src/display/window.hpp
+++ b/src/display/window.hpp
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <ncurses.h>
+#include <stdexcept>
 
 #include "display/colors.hpp"
 


### PR DESCRIPTION
Building on Arch Linux failed, throwing a `error: ‘runtime_error’ is not a member of ‘std’` error for both system_warning.cpp and falling_text.cpp due too a missing include (stdexcept).
I added the include statement for the library which should resolve this.